### PR TITLE
fix: ensure minimum degree is correct for PK when chunking lookups

### DIFF
--- a/halo2_proofs/src/plonk/keygen.rs
+++ b/halo2_proofs/src/plonk/keygen.rs
@@ -288,7 +288,7 @@ where
     #[cfg(not(feature = "circuit-params"))]
     let config = ConcreteCircuit::configure(&mut cs);
 
-    let cs = cs;
+    let cs = cs.chunk_lookups();
 
     if (params.n() as usize) < cs.minimum_rows() {
         return Err(Error::not_enough_rows_available(params.k()));


### PR DESCRIPTION
As noted in discussions with @therealyingtong the current MV lookup implementation has edge cases  for lookups whose expressions have degree higher than the max gate degree. 

In particular we found that when chunking lookups, the required degree calculated during VK and PK generation was mismatched. 

To force these degrees to match -- we chunk lookups on the `ConstraintSystem` during PK generation and find that this resolves issues for over 58 integration tests within https://github.com/zkonduit/ezkl .  