### PR TITLE
 fix: ensure minimum degree is correct for PK when chunking lookups

### DIFF
--- a/halo2_proofs/src/plonk/keygen.rs
+++ b/halo2_proofs/src/plonk/keygen.rs
@@ -274,7 +274,7 @@ where
     let mut cs = ConstraintSystem::default();
     let config = ConcreteCircuit::configure(&mut cs);
 
-    let cs = cs;
+    let cs = cs.chunk_lookups();
 
     if (params.n() as usize) < cs.minimum_rows() {
         return Err(Error::not_enough_rows_available(params.k()));


### PR DESCRIPTION
Duplicate of #3 but for main branch. 